### PR TITLE
Update version of html-minifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "gulp": "~3.8.1",
     "gulp-util": "~2.2.17",
-    "html-minifier": "^0.6.2",
+    "html-minifier": "^3.5.8",
     "map-stream": "^0.1.0",
     "through2": "~0.5.1"
   }


### PR DESCRIPTION
Current version of html-minifier has vulnerable dependency (uglify-js < 2.6.0)